### PR TITLE
upgrade vpc module version

### DIFF
--- a/lab-networking/network.tf
+++ b/lab-networking/network.tf
@@ -1,7 +1,7 @@
 # # Create the network
 module "vpc" {
   source  = "terraform-google-modules/network/google"
-  version = "~> 0.4.0"
+  version = "~> 3.2.2"
 
   # Give the network a name and project
   project_id   = "${google_project_service.compute.project}"


### PR DESCRIPTION
VPC module is a bit out of date and having difficulties running this lab with modern Terraform versions.

Keeping the module up to date seems to fix the lab for Qwiklabs.